### PR TITLE
no report_gdocs script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(name = "scilifelab",
       scripts = ['scripts/project_management.py',
                  'scripts/runsizes.py',
                  'scripts/bcbb_helpers/run_bcbb_pipeline.py',
+                 'scripts/bcbb_helpers/report_to_gdocs.py',
                  'scripts/bcbb_helpers/process_run_info.py'],
       install_requires = [
           "bcbio-nextgen >= 0.2",


### PR DESCRIPTION
(master)[perk@biologin 120821_BC118PACXX]$ run_bcbb_pipeline.py --only-run P281_125F_index2-post_process.yaml ../120821_BC118PACXX P281_125F_index2-bcbb-config.yaml
Traceback (most recent call last):
  File "/bubo/home/h12/perk/.virtualenvs/master/bin/run_bcbb_pipeline.py", line 5, in <module>
    pkg_resources.run_script('scilifelab==0.1dev', 'run_bcbb_pipeline.py')
  File "/bubo/home/h12/perk/.virtualenvs/master/lib/python2.7/site-packages/setuptools-0.6c12dev_r88846-py2.7.egg/pkg_resources.py", line 489, in run_script
  File "/bubo/home/h12/perk/.virtualenvs/master/lib/python2.7/site-packages/setuptools-0.6c12dev_r88846-py2.7.egg/pkg_resources.py", line 1214, in run_script
  File "/bubo/home/h12/perk/.virtualenvs/master/lib/python2.7/site-packages/scilifelab-0.1dev-py2.7.egg/EGG-INFO/scripts/run_bcbb_pipeline.py", line 16, in <module>

ImportError: No module named scilifelab.scripts.bcbb_helpers.report_to_gdocs
