### PR TITLE
Hotfix: using correct ps_map and mapping barcode names

### DIFF
--- a/tests/pm/test_pm_deliver.py
+++ b/tests/pm/test_pm_deliver.py
@@ -37,6 +37,17 @@ class PmProductionTest(PmTest):
         handler.register(DeliveryReportController)
         self._run_app()
 
+    def test_3_sample_status_ps_map(self):
+        self.app = self.make_app(argv = ['report', 'sample_status', '--user', self.user, '--password', self.pw, '--url', self.url, self.examples["project"], self.examples["flowcell"], '--debug'],extensions=['scilifelab.pm.ext.ext_couchdb'])
+        handler.register(DeliveryReportController)
+        self._run_app()
+
+    def test_3_project_status_ps_map(self):
+        self.app = self.make_app(argv = ['report', 'project_status', '--user', self.user, '--password', self.pw, '--url', self.url, self.examples["project"], '--debug'],extensions=['scilifelab.pm.ext.ext_couchdb'])
+        handler.register(DeliveryReportController)
+        self._run_app()
+
+
     def test_2_sample_status_custom(self):
         """Test sample status note generation with command line customizations"""
         self.app = self.make_app(argv = ['report', 'sample_status', '--user', self.user, '--password', self.pw, '--url', self.url, self.examples["project"], self.examples["flowcell"], '--debug', '--customer_reference', 'MyCustomerReference', '--uppnex_id', 'MyUppnexID', '--ordered_million_reads', '10', '--use_bc_map'],extensions=['scilifelab.pm.ext.ext_couchdb'])


### PR DESCRIPTION
This should correct the case where previously mapping from barcode name to project sample name failed.
