### PR TITLE
Normalize non-ascii strings in the report genration

### DIFF
--- a/scilifelab/report/rl.py
+++ b/scilifelab/report/rl.py
@@ -1,5 +1,6 @@
 """Reportlab module for generating pdf documents"""
 import os
+import unicodedata
 from datetime import datetime
 from pyPdf import PdfFileWriter, PdfFileReader
 from collections import OrderedDict


### PR DESCRIPTION
Reportlab does not support non-ascii characters (see [here](https://www.reportlab.com/docs/reportlab-userguide.pdf)), and therefore the report generation fails with swedish names :disappointed:. The changes introduced in this PR normalise non-ascii strings (i.e replaces ö --> o, ä/å --> a).
