### PR TITLE
[hotfix] Fix the way the dictionary of samples is parsed

### DIFF
--- a/scilifelab/report/delivery_notes.py
+++ b/scilifelab/report/delivery_notes.py
@@ -177,8 +177,11 @@ def _set_project_sample_dict(project_sample_item, source):
         if "library_prep" in project_sample_item.keys():
             sample_run_metrics = {k:v.get("sample_run_metrics", {}) for k,v in \
                                     project_sample_item["library_prep"].iteritems()}
-            project_sample_d = {metrics[0]:metrics[1]['sample_run_metrics_id'] \
-                                    for metrics in sample_run_metrics.items()}
+            project_sample_d = {}
+            for fc in sample_run_metrics.items():
+                fc, metrics = fc
+                for k, v in metrics.iteritems():
+                    project_sample_d[k] = v['sample_run_metrics_id']
         else:
             sample_run_metrics = project_sample_item.get("sample_run_metrics", {})
             project_sample_d = {metrics[0]:metrics[1]['sample_run_metrics_id'] \


### PR DESCRIPTION
This PR fixes a bug that caused the report generation to crash. The dictionary of samples was not being parsed correctly after the update to the new DB structure. 
