### PR TITLE
Scripts to perform md5sum checking of the fastq files in the runs

### DIFF
--- a/scripts/check_md5.sh
+++ b/scripts/check_md5.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+#SBATCH -A a2010002
+#SBATCH -t 6:00:00
+#SBATCH -p core
+#SBATCH -J md5sum_check
+#SBATCH --qos=seqver
+
+FCDIR=$1
+LOG=`basename ${1}`.md5_check
+echo $LOG
+rm -f $LOG
+
+cd $FCDIR
+for d in `ls -d Unaligned*`
+do
+  find $d -type f -name "*.md5" -exec md5sum -c '{}' \; >> $LOG
+  for f in `find $d -type f -name "*.fastq.gz"`
+  do
+    if [ ! -e ${f}.md5 ]
+    then
+      echo "FAIL: Missing .md5 file for $f" >> $LOG
+    fi
+  done
+done
+cd $OLDPWD

--- a/scripts/check_md5_cronjob.sh
+++ b/scripts/check_md5_cronjob.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ARCHIVE_DIR=/proj/a2010002/archive
+CHECK_MD5=$HOME/bin/check_md5.sh
+
+for fc_dir in `ls -d $ARCHIVE_DIR/1*XX`
+do
+    if [ ! -e $fc_dir/*md5_check ]
+    then
+        sbatch $CHECK_MD5 $fc_dir
+    fi
+done


### PR DESCRIPTION
- check_md5.sh: Performs the md5sum checking of a flowcell specified by parameter
- check_md5_cronjob.sh: Submits a SLURM job for those flowcells that have not already been checked.
