### PR TITLE
Added script to set up replication in CouchDB

### DIFF
--- a/scripts/couchdb_replication.py
+++ b/scripts/couchdb_replication.py
@@ -1,7 +1,8 @@
 import couchdb
 import json
 import argparse
-import logging
+import logbook
+import sys
 
 from couchdb import PreconditionFailed
 
@@ -12,6 +13,12 @@ if __name__=="__main__":
 
     Use this script if you want to configure a stage database that will have the
     exact same content of your production database.
+
+    To do so, the script creates a replication document for each database in the
+    source CouchDB instance that replicates such database (in continuous mode)
+    to the destination database.
+
+    Security object (permissions per database), are put to the destination databases.
     """
 
     parser = argparse.ArgumentParser(description=DESCRIPTION)
@@ -24,53 +31,49 @@ if __name__=="__main__":
     source = args.source
     dest = args.destination
 
-    l = logging.getLogger()
-    l.level = logging.INFO
-    h = logging.StreamHandler()
-    h.level = logging.INFO
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-    h.setFormatter(formatter)
-    l.addHandler(h)
+    l = logbook.Logger(level=logbook.INFO)
+    h = logbook.StreamHandler(sys.stdout, level=logbook.INFO)
 
     s_couch = couchdb.Server(source)
     d_couch = couchdb.Server(dest)
     _, _, s_dbs = s_couch.resource.get_json('_all_dbs')
     _, _, d_dbs = d_couch.resource.get_json('_all_dbs')
 
-    l.info("Databases in the source CouchDB instance: {}".format(', '.join(s_dbs)))
-    l.info("Databases in the destination CouchDB instance: {}".format(', '.join(d_dbs)))
+    with h.applicationbound():
+        l.info("Databases in the source CouchDB instance: {}".format(', '.join(s_dbs)))
+        l.info("Databases in the destination CouchDB instance: {}".format(', '.join(d_dbs)))
 
-    #We don't want to replicate the replicator DB
-    try:
-        s_dbs.remove('_replicator')
-        d_dbs.remove('_replicator')
-    except ValueError:
-        pass
-
-    #For each DB in the source CouchDB instance, create a replication document
-    #and get its _security object to put it in the destination database
-    for db in s_dbs:
-        _, _, security = s_couch[db].resource.get_json('_security')
-        doc = {
-                'name': '{}_rep'.format(db),
-                'source': '{}/{}/'.format(source, db),
-                'target': '{}/{}/'.format(dest, db),
-                'continuous': True
-        }
-        s_rep = s_couch['_replicator']
-
-        #Create the DB in the destination if not present
+        #We don't want to replicate the replicator DB
         try:
-            d_couch.create(db)
-            l.info("Created {} database in destination".format(db))
-        except PreconditionFailed:
-            l.info("Database {} already existing in the destination, not creating it".format(db))
+            s_dbs.remove('_replicator')
+            d_dbs.remove('_replicator')
+        except ValueError:
+            pass
 
-        #Put the replicator document in source and set security object in destination
-        l.info("Putting replicator document in _replicator database of source")
-        s_rep.create(doc)
-        l.info("Copying security object to {} database in destination".format(db))
-        d_couch[db].resource.put('_security', security)
+        #For each DB in the source CouchDB instance, create a replication document
+        #and get its _security object to put it in the destination database
+        for db in s_dbs:
+            _, _, security = s_couch[db].resource.get_json('_security')
+            doc = {
+                    'name': '{}_rep'.format(db),
+                    'source': '{}/{}/'.format(source, db),
+                    'target': '{}/{}/'.format(dest, db),
+                    'continuous': True
+            }
+            s_rep = s_couch['_replicator']
 
-    l.info("DONE!")
+            #Create the DB in the destination if not present
+            try:
+                d_couch.create(db)
+                l.info("Created {} database in destination".format(db))
+            except PreconditionFailed:
+                l.info("Database {} already existing in the destination, not creating it".format(db))
+
+            #Put the replicator document in source and set security object in destination
+            l.info("Putting replicator document in _replicator database of source")
+            s_rep.create(doc)
+            l.info("Copying security object to {} database in destination".format(db))
+            d_couch[db].resource.put('_security', security)
+
+        l.info("DONE!")
 


### PR DESCRIPTION
This script set up replication between a source and a destination CouchDB instance.

The reason to put the _security attribute separately from the rest of the database content is that this is a special document that cannot be replicated in a standard way. Cite from [here](http://wiki.apache.org/couchdb/Security_Features_Overview#Authorization):

> Note that security objects are not regular versioned documents (that is, they are not under MVCC rules). This is a design choice to speedup authorization checks
