### PR TITLE
Add option to clone StatusDB

### DIFF
--- a/scripts/couchdb_replication.py
+++ b/scripts/couchdb_replication.py
@@ -5,30 +5,42 @@ import json
 import argparse
 import logbook
 import sys
+import os
+import ConfigParser
 
 from couchdb import PreconditionFailed
 
 #Set up logging
-l = logbook.Logger(level=logbook.INFO)
+l = logbook.Logger("CouchDB replicator", level=logbook.INFO)
 h = logbook.StreamHandler(sys.stdout, level=logbook.INFO)
+
+
+def _get_config():
+    """Looks for a configuration file and load credentials.
+    """
+    config = ConfigParser.SafeConfigParser()
+    try:
+        with open(os.path.join(os.environ['HOME'], '.couchrc'), 'r') as f:
+            config.readfp(f)
+
+        SOURCE = config.get('replication', 'SOURCE').rstrip()
+        DESTINATION = config.get('replication', 'DESTINATION').rstrip()
+    except:
+        l.error("Please make sure you've created your own configuration file \
+            (i.e: ~/.couchrc)")
+        sys.exit(-1)
+    return SOURCE, DESTINATION
 
 
 def _get_databases_info(source, destination):
     """Returns a tuple containing a python representation of source and destination
-    couchDB instances. It also returns a list of the databases in both instances.
+    couchDB instances. It also returns a list of the databases in both instances
+    (excluding the _replicator database).
     """
     s_couch = couchdb.Server(source)
     d_couch = couchdb.Server(destination)
     _, _, s_dbs = s_couch.resource.get_json('_all_dbs')
     _, _, d_dbs = d_couch.resource.get_json('_all_dbs')
-    return s_couch, d_couch, s_dbs, d_dbs
-
-
-
-def _setup_continuous(source, destination):
-    """Set up a continuous replication of all databases in source to destination.
-    """
-    s_couch, d_couch, s_dbs, d_dbs = _get_databases_info(source, destination)
 
     l.info("Databases in the source CouchDB instance: {}".format(', '.join(s_dbs)))
     l.info("Databases in the destination CouchDB instance: {}".format(', '.join(d_dbs)))
@@ -39,6 +51,14 @@ def _setup_continuous(source, destination):
         d_dbs.remove('_replicator')
     except ValueError:
         pass
+
+    return s_couch, d_couch, s_dbs, d_dbs
+
+
+def _setup_continuous(source, destination):
+    """Set up a continuous replication of all databases in source to destination.
+    """
+    s_couch, d_couch, s_dbs, d_dbs = _get_databases_info(source, destination)
 
     #For each DB in the source CouchDB instance, create a replication document
     #and get its _security object to put it in the destination database
@@ -65,8 +85,37 @@ def _setup_continuous(source, destination):
         l.info("Copying security object to {} database in destination".format(db))
         d_couch[db].resource.put('_security', security)
 
-        l.info("DONE!")
+    l.info("DONE!")
 
+
+def _clone(source, destination):
+    """Creates a complete clone of source in destination.
+
+    WARNING: This action will remove ALL content from destination.
+    """
+    l.info("Performing a complete clone from source to destination")
+    s_couch, d_couch, s_dbs, d_dbs = _get_databases_info(source, destination)
+
+    #Delete all databases in destination
+    l.info("Removing all databases from destination")
+    for db in d_dbs:
+        d_couch.delete(db)
+
+    #Create all databases abailable in source to destination. Copy data and
+    #permissions
+    l.info("Re-creating databases from source into destination")
+    for db in s_dbs:
+        #The users database is never deleted
+        if not db == '_users':
+            d_couch.create(db)
+        _, _, security = s_couch[db].resource.get_json('_security')
+        source_db = '/'.join([source, db])
+        dest_db = '/'.join([destination, db])
+        l.info("Copying data from {} in source to destination".format(db))
+        d_couch.replicate(source_db, dest_db)
+        l.info("Copying security object to {} database in destination".format(db))
+
+    l.info("DONE!")
 
 
 if __name__ == "__main__":
@@ -86,9 +135,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument('action', type=str, help = "Action to perform, either \
             configure continuous replication (continuous) or punctual clone (clone)")
-    parser.add_argument('source', type=str, help = "Source CouchDB instance, \
+    parser.add_argument('--source', type=str, help = "Source CouchDB instance, \
             with the credentials included in the URL. I.E: http://admin:passw@source_db:5984")
-    parser.add_argument('destination', type=str, help = "Destination CouchDB instance, \
+    parser.add_argument('--destination', type=str, help = "Destination CouchDB instance, \
             with the credentials included in the URL. I.E: http://admin:passw@destination_db:5984")
 
     args = parser.parse_args()
@@ -96,11 +145,16 @@ if __name__ == "__main__":
     destination = args.destination
     action = args.action
 
+    if not all([source, destination]):
+        source, destination = _get_config()
+
     with h.applicationbound():
         actions = ['continuous', 'clone']
         if action not in actions:
             raise ValueError("Action not recognised, please choose between %s" % \
                     ', '.join(actions))
+        l.info("Starting replication - source: {}, destination: {}".format( \
+                source.split('@')[-1], destination.split('@')[-1]))
         if action == "continuous":
             _setup_continuous(source, destination)
         else:


### PR DESCRIPTION
I've modified the couchdb_replication script that I made to configure continuous replication and added an option to clone completely the database, as we discussed. 

I've also added an option to load the credentials from a configuration file, otherwise they will be visible, as you have to put them in the http requests. In summary, the new option does:
- Removes all databases from destination.
- Creates all databases present in source into destination, copy the data and the permissions.
