### PR TITLE
fix path when merging configs

### DIFF
--- a/scilifelab/bcbio/__init__.py
+++ b/scilifelab/bcbio/__init__.py
@@ -153,14 +153,14 @@ def merge_sample_config(flist, sample, out_d, dry_run=True):
         runinfo = conf.get("details") if conf.get("details", None) else conf
         for i in range(0, len(runinfo)):
             for j in range(0, len(runinfo[i].get("multiplex"))):
-                seqfiles = [os.path.join(os.path.dirname(f), x) for x in runinfo[i]["multiplex"][0]["files"]]
+                seqfiles = runinfo[i]["multiplex"][0]["files"]
                 target_seqfiles = [os.path.join(out_d, os.path.basename(x).replace(sample, "{}_{}".format(sample, runinfo[i]["flowcell_id"]))) for x in seqfiles]
                 [dry_rsync(src, tgt, dry_run=dry_run) for src, tgt in izip(seqfiles, target_seqfiles)]
                 info = {}
                 info["lane"] = str(lane)
                 info["analysis"] = runinfo[i]["analysis"]
                 info["description"] = str(sample)
-                info["files"] = target_seqfiles
+                info["files"] = target_seqfiles 
                 info["genome_build"] = runinfo[i]["genome_build"]
                 newconf['details'].append(info)
                 lane = lane + 1

--- a/scilifelab/bcbio/run.py
+++ b/scilifelab/bcbio/run.py
@@ -160,7 +160,7 @@ def setup_merged_samples(flist, sample_group_fn=_group_samples, **kw):
             # Setup merged bcbb-config file
             bcbb_config = merge_sample_config(v.values(), sample=k, out_d=out_d, dry_run=kw.get('dry_run', True))
             bcbb_config_file = os.path.join(out_d, os.path.basename(v.values()[0]))
-            bcbb_config = sort_sample_config_fastq(bcbb_config)
+            bcbb_config = sort_sample_config_fastq(bcbb_config, path=out_d)
             if not os.path.exists(bcbb_config_file) or kw.get('new_config', False):
                 dry_unlink(bcbb_config_file, dry_run=kw.get('dry_run', True))
                 dry_write(bcbb_config_file, yaml.safe_dump(bcbb_config, default_flow_style=False, allow_unicode=True, width=1000), dry_run=kw.get('dry_run', True))


### PR DESCRIPTION
- When merging config files to run merged analysis, the path to fastq files in subfolders need to be included in order to find the files. Otherwise, the script will crash.
