### PR TITLE
Script to backup all our repositories

### DIFF
--- a/scripts/backup_github.py
+++ b/scripts/backup_github.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+import logbook
+
+from subprocess import check_call
+from subprocess import CalledProcessError
+
+import pygithub3
+
+LOG = logbook.Logger('GitHub Backup')
+
+
+track_all_branches = """
+for branch in `git branch -a | grep remotes | grep -v HEAD | grep -v master`; do
+    git branch --track ${branch##*/} $branch
+done
+"""
+
+
+class cd(object):
+    """Changes the current working directory to the one specified
+    """
+
+    def __init__(self, path):
+        self.original_dir = os.getcwd()
+        self.dir = path
+
+    def __enter__(self):
+        os.chdir(self.dir)
+
+    def __exit__(self, type, value, tb):
+        os.chdir(self.original_dir)
+
+
+def backup(user, dest):
+    """Performs a backup of all the repos in user's GitHub account on dest
+    """
+    gh = pygithub3.Github()
+    repos = gh.repos.list(user=user, type='all')
+    for repo in repos.all():
+        repo_path = os.path.join(dest, repo.name)
+        LOG.info("Backing up repository {}".format(repo.name))
+        #If the repository is present on destination, update all branches
+        if os.path.exists(repo_path):
+            LOG.info("The repository {} already exists on destination. Pulling " \
+                     "all branches".format(repo.name))
+            with cd(repo_path):
+                try:
+                    cl = ['git', 'up']
+                    check_call(cl)
+                except CalledProcessError:
+                    LOG.error("There was an error fetching the branches from " \
+                              "the repository {}, skipping it".format(repo.name))
+                    pass
+        #Otherwise clone the repository and fetch all branches
+        else:
+            LOG.info("The repository {} does not exist on destination. " \
+                     "Cloning it. ".format(repo.name))
+            try:
+                cl1 = ['git', 'clone', '-q', repo.clone_url, repo_path]
+                check_call(cl1)
+                with cd(repo_path):
+                    check_call(track_all_branches, shell=True)
+            except CalledProcessError:
+                LOG.error('Error cloning repository {}, skipping it'.format(repo.name))
+                pass
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description="Clones all the public " \
+            "repositories from a GitHub account")
+    parser.add_argument("user", type=str, help="GitHub username")
+    parser.add_argument("-d", type=str, help="Destination of the copy")
+    args = parser.parse_args()
+
+    user = args.user
+    dest = os.getcwd() if not args.d else args.d
+
+    print user, dest
+    backup(user, dest)


### PR DESCRIPTION
This script can be used to clone all the repositories from a GitHub user:

```
(github)guillem@guillemmac:~/repos/scilifelab/scripts (github)$ python backup_github.py --help
usage: backup_github.py [-h] [-d D] user

Clones all the public repositories from a GitHub account

positional arguments:
  user        GitHub username

optional arguments:
  -h, --help  show this help message and exit
  -d D        Destination of the copy
```

[Here](http://pastebin.com/0juZiwW5) you can find the output of the first execution of `backup_github.py SciLifeLab -d backup`.
[Here](http://pastebin.com/bHgzLcek) the output of a second execution, where all branches are updated.

_Note_: I know that the embedded bash command is not the most beautiful thing, but is the only way I found to track all branches so that we can pull from them later. The thing is that if you do a `git clone`, this is a complete backup containing everything: commit history, tags, branches, etc. **But**, if the repository already exists you cannot clone, and what you have to do is pull from all branches. And here is the problem, you cannot pull form branches that you haven't previously tracked. So that's why this dirty bash command that tracks all the runs, so that `git up` can later on pull from all branches. 
