### PR TITLE
Do not overwrite [illumina][run_summary]. Fixes #341

### DIFF
--- a/scilifelab/db/statusdb.py
+++ b/scilifelab/db/statusdb.py
@@ -240,6 +240,9 @@ def update_fn(cls, db, obj, viewname = "names/id_to_name", key="name"):
         obj["modification_time"] = t_utc
         obj["_rev"] = dbobj.get("_rev")
         obj["_id"] = dbobj.get("_id")
+        #Do not overwrite the content of the field [illumina][run_summary]
+        if obj.has_key('illumina') and dbobj.get('illumina', {}).has_key('run_summary'):
+            obj['illumina']['run_summary'] = dbobj['illumina']['run_summary']
         return (obj, dbid)
 
 ##############################


### PR DESCRIPTION
As the description says, this code should fix issue #341. I have been testing it on tools-dev with [this](http://tools-dev.scilifelab.se:5984/_utils/document.html?flowcells/6aaf23ed1f4b444c9704640f326971c2) flowcell document.

Before this change indeed the item [illumina][run_summary] was deleted. After this change the item is kept there. You can test it running `pm qc upload-qc 131217_SN7001362_0105_BC3HTJACXX` **on tools-dev.scilifelab.se**.
