### PR TITLE
Add option to skip copying security objects

### DIFF
--- a/scripts/couchdb_replication.py
+++ b/scripts/couchdb_replication.py
@@ -150,8 +150,6 @@ if __name__ == "__main__":
     security = False if args.no_security else True
     action = args.action
 
-    import ipdb; ipdb.set_trace()
-
     if not all([source, destination]):
         source, destination = _get_config()
 


### PR DESCRIPTION
This code is useful in case we want to have different permissions for production and stage databases. 
