### PR TITLE
Add --with-exceptions option

### DIFF
--- a/scripts/couchdb_replication.py
+++ b/scripts/couchdb_replication.py
@@ -174,8 +174,8 @@ def _set_roles(server):
     security_obj['admins']['roles'] = config.roles['admins']
     security_obj['members']['roles'] = config.roles['members']
 
-    l.info("Setting roles to destination databases: {}".format(str(security_obj)))
     s_couch, d_couch, s_dbs, d_dbs = _get_databases_info(source, destination)
+    l.info("Setting roles to destination databases: {}".format(str(security_obj)))
     for db in d_dbs:
         d_couch[db].resource.put('_security', security_obj)
 


### PR DESCRIPTION
We need a way of removing certain documents after we clone the database, otherwise the validation functions are copied from tools to tools-dev and therefore developers cannot work on tools-dev. This PR allows that, and fixes a bug that made the option --so-security to be ignored. Other additions:
- Config() singleton class that holds configuration
- `--set-roles` option that reads from .couchrc the roles to set after cloning:

```
[roles]
members = list,of,members
admins = list,of,admins
```
