### PR TITLE
Raw data delivery uncompressed fastq

### DIFF
--- a/scilifelab/pm/core/deliver.py
+++ b/scilifelab/pm/core/deliver.py
@@ -287,7 +287,7 @@ class DeliveryController(AbstractBaseController):
         for sample in samples:
             date = sample.get("date",False)
             fcid = sample.get("flowcell",False)
-            dname = sample.get("barcode_name",False)
+            dname = sample.get("barcode_name","")
             runname = "{}_{}".format(date,fcid)
 
             path = os.path.join(proj_base_dir,dname,runname,"*.fastq")


### PR DESCRIPTION
User will be prompted to continue when sample analysis dir contains uncompressed fastq files.
Because a warning buried in a wall of text is not enough
