### PR TITLE
Crontab information to StatusDB

### DIFF
--- a/scripts/update_cronjobs_database.py
+++ b/scripts/update_cronjobs_database.py
@@ -78,5 +78,6 @@ if __name__=='__main__':
         couch.resource.credentials = (user, password)
         update_cronjobs_database(couch)
     except IOError as e:
-        raise e("Please make sure you've created your own configuration file " +  
-            "(i.e: ~/.pm/pm.conf), and that it contains a source and a destination servers")
+        print "Please make sure you've created your own configuration file " + \
+              "(i.e: ~/.pm/pm.conf), and that it contains a source and a destination servers"
+        raise


### PR DESCRIPTION
Will fetch information of the user's crontab on the server where it is running and create the corresponding document in a database called "cronjobs".

This addresses part of [this](https://trello.com/c/1hSc6jVd/307-cronjobs-database-in-statusdb-and-view-in-genstat) Trello card.
