### PR TITLE
Show fastq_screen metrics for a given project-flowcell

### DIFF
--- a/scripts/check_cont_casava.sh
+++ b/scripts/check_cont_casava.sh
@@ -1,0 +1,37 @@
+ #!/bin/bash
+# Wraper for checking fastq_screen results for a specific project and flowcell
+# Assumes casava structure
+
+if [ $# -ne 2 ]; then
+  echo "Usage:
+        check_cont_casava.sh <flowcell id> <project id>
+
+        Arguments:
+        <flowcell id>
+                - eg: 120127_BD0H2HACXX
+        <project id>
+                - eg: M.Muurinen_11_01a"
+  exit
+fi
+
+fcID=$1
+project_id=$2
+
+dir=`pwd`
+
+cd  /gulo/proj_nobackup/a2010002/illumina
+
+grep Human ${project_id}/*/${fcID}/fastq_screen/*.txt | sed 's/:/\//g' | cut -f 2,6 -d '/'
+echo ''
+grep Mouse ${project_id}/*/${fcID}/fastq_screen/*.txt | sed 's/:/\//g' | cut -f 2,6 -d '/'
+echo ''
+grep Ecoli ${project_id}/*/${fcID}/fastq_screen/*.txt | sed 's/:/\//g' | cut -f 2,6 -d '/'
+echo ''
+grep Spruce ${project_id}/*/${fcID}/fastq_screen/*.txt | sed 's/:/\//g' | cut -f 2,6 -d '/'
+echo ''
+grep PhiX ${project_id}/*/${fcID}/fastq_screen/*.txt | sed 's/:/\//g' | cut -f 2,6 -d '/'
+
+
+cd $dir
+
+


### PR DESCRIPTION
This is @mayabrandi 's script **as it is**. It will actually work the same way with the new fastq_screen output.

This is an example of the old output:

```
Library Unmapped        Mapped_One_library      Mapped_Multiple_Libraries
Spruce  100.00  0.00    0.00
```

This is an example of the new output:

```
Library #Reads_processed    #Unmapped   %Unmapped   #One_hit_one_library    %One_hit_one_library    #Multiple_hits_one_library  %Multiple_hits_one_library  #One_hit_multiple_libraries %One_hit_multiple_libraries Multiple_hits_multiple_libraries    %Multiple_hits_multiple_libraries
phiX    100 0   0.00    100 100.00  0   0.00    0   0.00    0   0.00

%Hit_no_libraries: 0.00
```

If you take a look at the code, the result of the grep commands will be the same in both cases: Just output the whole line.
