### PR TITLE
Easy PR - To transfer only mentioned flowcell data!!

### DIFF
--- a/scilifelab/pm/core/production.py
+++ b/scilifelab/pm/core/production.py
@@ -82,6 +82,8 @@ class ProductionController(AbstractExtendedBaseController, BcbioRunController):
         def bcbb_yaml_filter(f):
             return re.search(pattern, f) != None
         samples = filtered_walk(os.path.join(self._meta.root_path, self._meta.path_id), bcbb_yaml_filter)
+        if self.pargs.flowcell:
+            samples = [sam for sam in samples if os.path.basename(os.path.dirname(sam)) == self.pargs.flowcell]
         for s in samples:
             fc = Flowcell(s)
             fc_new = fc.subset("sample_prj", self.pargs.project)


### PR DESCRIPTION
The "pm production transfer" command which is used to transfer(copy) raw data to BP analysis directory lacks or doesn't bother to copy only the mentioned flowcell when user wants it to do so x-( Hope this fix will work!!
