### PR TITLE
Fixes close date = Null

### DIFF
--- a/scilifelab/lims_utils/objectsDB.py
+++ b/scilifelab/lims_utils/objectsDB.py
@@ -126,6 +126,8 @@ class ProjectDB():
                         self.project['first_initial_qc'] = initial_qc_start_date
                 except:
                     pass
+        self.project = delete_Nones(self.project)
+
     def build_processes_per_artifact(self,lims, pname):
         """Constructs a dictionary linking each artifact id with its processes.
         Other artifacts can be present as keys. All processes where the project is
@@ -144,7 +146,6 @@ class ProjectDB():
 
         return processes_per_artifact
 
-        self.project = delete_Nones(self.project)
 
 
 #############-------------- ProcessInfo class and help functions --------------#############


### PR DESCRIPTION
so @remiolsen found that PSUL suddently uploaded empty close_dates to status db, and since the check only looks for the presence of the key rather than its value, a lot of projects were marked closed.

What happens it that he object to upload was always given a close_date = null, but the last operation on this object was to clear out all the empty values. As I added code, this instruction shifted to the right, making it belonging to another block which was not executed all the time. While I would like to blame this on python (it would not have happened with braces) or even on statusdb (not monitoring the value ), this is mainly my fault anyway. 
So here is the fix.
