### PR TITLE
BigFix: Use tarball id if sending a tarball

### DIFF
--- a/scilifelab/pm/core/archive.py
+++ b/scilifelab/pm/core/archive.py
@@ -104,7 +104,8 @@ class ArchiveController(AbstractExtendedBaseController):
                                               password=db_info.get('password'),
                                               url=db_info.get('url'))
         swestore_paths = set(self.config.get('archive','swestore_staging').split(','))
-        swestore_dir = get_path_swestore_staging(self.pargs.flowcell, swestore_paths)
+        run = self.pargs.tarball if self.pargs.tarball else self.pargs.flowcell
+        swestore_dir = get_path_swestore_staging(run, swestore_paths)
         # Create a tarball out of the run folder
         if self.pargs.package_run:
 

--- a/scilifelab/pm/core/production.py
+++ b/scilifelab/pm/core/production.py
@@ -401,7 +401,8 @@ class ProductionController(AbstractExtendedBaseController, BcbioRunController):
         storage_conf = self.app.config.get_section_dict('storage')
         archive_conf = self.app.config.get_section_dict('archive')
         swestore_paths = set(self.app.config.get_section_dict('archive').get('swestore_staging').split(','))
-        swestore_dir = get_path_swestore_staging(self.pargs.flowcell, swestore_dir)
+        run = self.pargs.tarball if self.pargs.tarball else self.pargs.flowcell
+        swestore_dir = get_path_swestore_staging(run, swestore_dir)
         servers = [server for server in storage_conf.keys()]
         server = platform.node().split('.')[0].lower()
         flowcell = self.pargs.flowcell


### PR DESCRIPTION
If sending a tarball to swestore (not a raw ran to compress & send), it will try to use the `--flowcell` argument as run id, but won't find it, use `--tarball` instead.

Example command to send a raw run:

```
pm archive swestore --package-run --pbzip2 --check-finished --send-to-swestore --swestore-path a2010002 --flowcell [RUN_ID] --clean-swestore --force --clean-from-staging
```

Example command to send an already tarballed run:

```
pm archive swestore --send-to-swestore --swestore-path a2010002 --tarball [RUN_ID].tar.bz2 --clean-swestore --clean-from-staging
```
