### PR TITLE
fixes B.Bergman_14_02 not updating

### DIFF
--- a/scilifelab/lims_utils/objectsDB.py
+++ b/scilifelab/lims_utils/objectsDB.py
@@ -49,6 +49,8 @@ def get_last_first(process_list, last=True):
     if process_list:
         process = process_list[0]
         for pro in process_list:
+            if pro['date'] is None:
+                continue
             new_date = int(pro['date'].replace('-',''))
             old_date = int(process['date'].replace('-',''))
             if last and (new_date > old_date):


### PR DESCRIPTION
This is an ugly fix, and I am aware of that. However, someone I will not name (name begins with a 'S' and ends with 'verker') wants to be able to update B.Bergman13_02.

I'll look deeper into this when I'll have time, but for now, this works and can't break anything that is not already broken.

Details : 24-34649 Aggregate QC (Library Validation) has no date in the lims. That makes the ['date'] accesses return None, and None.replace() is not very effective.
