### PR TITLE
Adapt for changes in PostgreSQL 9.3.x

### DIFF
--- a/scripts/dbsync.sh
+++ b/scripts/dbsync.sh
@@ -18,7 +18,7 @@ echo "Current active sessions:"
 ssh $STAGING "psql -U $DB_USER $DB -c 'SELECT * FROM pg_stat_activity'"
 
 echo "Killing all active PostgresSQL sessions on $STAGING..."
-ssh $STAGING "psql -U $DB_USER $DB -c 'SELECT pg_terminate_backend(pg_stat_activity.procpid) FROM pg_stat_activity WHERE procpid <> pg_backend_pid();'"
+ssh $STAGING "psql -U $DB_USER $DB -c 'SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid();'"
 echo "return code: $?"
 
 #Implicit pause to give pgsql time to drop all connection


### PR DESCRIPTION
This column has changed in PostgreSQL 9.3.x and our replication script was not working. Now it does.

References: http://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=4f42b546fd87a80be30c53a0f2c897acb826ad52
