### PR TITLE
Modified preseq plot_complexity_curves.py script

### DIFF
--- a/scripts/plot_complexity_curves.py
+++ b/scripts/plot_complexity_curves.py
@@ -69,8 +69,8 @@ def main(ccurves, output_name='complexity_curves', x_min=0, x_max=500000000):
     plt.ylim(0, global_y_max_ccurve_limit + global_y_max_ccurve_limit*0.2)
     
     # label the axis
-    plt.ylabel('Unique Reads')
-    plt.xlabel('Total Reads (including duplicates)')
+    plt.ylabel('Unique Molecules')
+    plt.xlabel('Total Molecules (including duplicates)')
     plt.title("preseq Complexity Curves")
     
     # Sort out some of the nastier plotting defaults


### PR DESCRIPTION
**Note** - this is just to make it clear what has changed in this script. After it's been merged I'll port the script across into the [visualisations](https://github.com/SciLifeLab/visualizations) repo...

Updates:
- Rewrote how the argparsing worked
  - Just supplying filenames without having to use a `--ccurves` parameter
  - Making output filename have a default and not be required
  - Changing how the variables are delivered to `main()`, now in a named way
- Legend updates
  - Legend now below plot
  - File extensions truncated from sample names
  - If sample name starts with `accepted_hits_sorted_dupRemoved_`, this is truncated
  - Legend columns, margins and plot size are dynamically determined by size of legend text
- Axes updates
  - Font size increased
  - Axes ticks now on the outside
  - Labels changed
