### PR TITLE
Bug!! So fix it!!

### DIFF
--- a/scilifelab/pm/core/deliver.py
+++ b/scilifelab/pm/core/deliver.py
@@ -579,7 +579,7 @@ class BestPracticeReportController(AbstractBaseController):
         if not self._check_pargs(["project"]):
             return
         if not self.pargs.statusdb_project_name:
-            self.statusdb_project_name = self.pargs.project
+            self.pargs.statusdb_project_name = self.pargs.project
         kw = vars(self.pargs)
         basedir = os.path.abspath(os.path.join(self.app.controller._meta.root_path, self.app.controller._meta.path_id))
         flist = find_samples(basedir, **vars(self.pargs))


### PR DESCRIPTION
A small bug that results in no barcode or user name for samples in BP report. 
Hopefully this should be the cause of that :stuck_out_tongue:
