### PR TITLE
Address validation too strict

### DIFF
--- a/scilifelab/report/survey.py
+++ b/scilifelab/report/survey.py
@@ -147,7 +147,7 @@ def initiate_survey(report, project, **kw):
     # verify the format of the email address
     recipients = []
     for email in emails:
-        if email is None or not re.match(r'^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$', email, re.IGNORECASE):
+        if email is None or not re.match(r'[^@]+@[^@]+\.[^@]+', email):
             report.log.warn("Illegal email format: {}".format(email))
             continue
         recipients.append(email)


### PR DESCRIPTION
Email addresses should be case insensitive... Well they are actually not according to RFC 2821 - the first part (before @) is sensitive - but damn mailbox providers that obey this rule. :neckbeard: 

Never mind all the other complicated non-sense that can into an address (+ signs, domain names etc..) 
