### PR TITLE
deliver selected FC or sample for BP analysis

### DIFF
--- a/scilifelab/pm/core/deliver.py
+++ b/scilifelab/pm/core/deliver.py
@@ -358,11 +358,9 @@ class DeliveryController(AbstractBaseController):
             self.app.cmd.safe_makedir(outpath)
         kw = vars(self.pargs)
         basedir = os.path.abspath(os.path.join(self._meta.root_path, self._meta.path_id))
-        flist = find_samples(basedir, **vars(self.pargs))
+        flist = find_samples(basedir, sample=self.pargs.sample, **vars(self.pargs))
         if self.pargs.flowcell:
             flist = [ fl for fl in flist if os.path.basename(os.path.dirname(fl)) == self.pargs.flowcell ]
-        if self.pargs.sample:
-            flist = [ fl for fl in flist if os.path.basename(fl).split('-')[0] == self.pargs.sample ]
         if not len(flist) > 0:
             self.log.info("No samples/sample configuration files found")
             return


### PR DESCRIPTION
At present we cant deliver selected "flowcell" or "sample" for BP data. `flist` is nothing but list for `-bcbb.config.yaml` files with absolute path. So this PR should fix it. 
