### PR TITLE
dont copy yaml files to user

### DIFF
--- a/scilifelab/pm/core/deliver.py
+++ b/scilifelab/pm/core/deliver.py
@@ -369,7 +369,7 @@ class DeliveryController(AbstractBaseController):
                 return
             return re.search(pattern, f) != None
         # Setup pattern
-        plist = [".*.yaml$", ".*.metrics$"]
+        plist = [".*.metrics$"]
         if not self.pargs.no_bam:
             plist.append(".*-{}.bam$".format(self.pargs.bam_file_type))
             plist.append(".*-{}.bam.bai$".format(self.pargs.bam_file_type))


### PR DESCRIPTION
As of now, when we deliver BP result it is copying all `.yaml` files including `post_process.yaml` which has some information not meant for the user. So we don't copy them anymore :)